### PR TITLE
Add CodeBoarding architecture analysis

### DIFF
--- a/.github/workflows/codeboarding-sync.yml
+++ b/.github/workflows/codeboarding-sync.yml
@@ -1,0 +1,52 @@
+name: CodeBoarding sync
+
+on:
+  push:
+    branches: ['main']
+    # Loop guard: don't re-trigger on the files this workflow itself commits.
+    # List generated files only: user-authored scope configuration must still trigger
+    # regeneration, while a merged sync PR must not trigger a loop.
+    paths-ignore:
+      - '.codeboarding/*.md'
+      - '.codeboarding/analysis.json'
+      - '.codeboarding/fingerprint.json'
+      - '.codeboarding/static_analysis.pkl'
+      - '.codeboarding/static_analysis.sha'
+      - '.codeboarding/codeboarding_version.json'
+      - '.codeboarding/health/health_report.json'
+      - 'docs/development/architecture.md'
+  workflow_dispatch:
+    inputs:
+      force_full:
+        description: 'Ignore the committed baseline and rebuild it from scratch (full analysis).'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write   # commit the generated baseline + docs to the branch
+  pull-requests: write # open/update the rolling baseline PR for a protected target branch
+  id-token: write   # identifies this repo to CodeBoarding's hosted tier — used by the free
+                    # tier AND a license, and as the fallback until your own key exists
+
+concurrency:
+  # Serialize against itself so a push landing mid-run can't make two commits.
+  group: codeboarding-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: CodeBoarding/CodeBoarding-action@v1
+        with:
+          mode: sync
+          force_full: ${{ inputs.force_full || false }}
+          sync_strategy: pull_request
+          target_branch: 'main'
+          # Free tier needs no secret — these fall through to the hosted OIDC tier when
+          # unset. Add either repo secret (Settings → Secrets and variables → Actions)
+          # for more/unmetered usage; no YAML edit required.
+          llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}   # BYO LLM provider key (OpenRouter)
+          license_key: ${{ secrets.CODEBOARDING_LICENSE }}  # CodeBoarding paid plan

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -1,0 +1,39 @@
+name: CodeBoarding review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, closed]
+  issue_comment:
+    types: [created]
+
+# No workflow-level permissions: each job requests only what it needs (least
+# privilege), so the default token starts with none.
+permissions: {}
+
+concurrency:
+  group: codeboarding-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read        # check out the repo + read the committed baseline (no writes in review mode)
+      pull-requests: write  # post the architecture-diff PR comment
+      issues: write         # the /codeboarding issue_comment trigger + comment API
+      id-token: write       # mint a GitHub OIDC token for the free hosted tier (write is the only level for id-token)
+    if: >
+      (github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.draft == false &&
+       github.head_ref != 'codeboarding/sync') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/codeboarding') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    steps:
+      - uses: CodeBoarding/CodeBoarding-action@v1
+        with:
+          # Free tier needs no secret — these fall through to the hosted OIDC tier when
+          # unset. Add either repo secret (Settings → Secrets and variables → Actions)
+          # for more/unmetered usage; no YAML edit required.
+          llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}   # BYO LLM provider key (OpenRouter)
+          license_key: ${{ secrets.CODEBOARDING_LICENSE }}  # CodeBoarding paid plan


### PR DESCRIPTION
This PR adds the [CodeBoarding](https://codeboarding.org) GitHub Action via **two workflows**:

- **`codeboarding-sync.yml`** — on every push to `main`, commits
  `.codeboarding/analysis.json` (your architecture baseline + readable docs). This is
  what the [CodeBoarding viewer](https://app.codeboarding.org) opens.
- **`codeboarding.yml`** — on every pull request, posts an architecture-diff comment and
  uploads that PR’s analysis as a build artifact for the viewer’s PR diff.

Both are needed: sync produces the baseline; review diffs against it.

### Sync delivery
Sync opens and keeps one rolling CodeBoarding PR into `main`; merge it to land the baseline.

### Works out of the box
Just merge it — the Action runs on the **free tier**, with no extra setup. The
`id-token: write` permission lets it identify your repo to CodeBoarding’s hosted LLM,
metered against a weekly limit for the repository owner.

### Want more, or unmetered, usage?
The workflows already wire two repository secrets — just add whichever you have under
[**Settings → Secrets and variables → Actions**](https://github.com/CodeBoarding/CodeBoarding-MCP/settings/secrets/actions/new) and the next run picks it up (no YAML edit):

- **`OPENROUTER_API_KEY`** — your own [OpenRouter](https://openrouter.ai) key (BYO key).
- **`CODEBOARDING_LICENSE`** — a [CodeBoarding](https://codeboarding.org) paid plan (unmetered).

A key wins if both are set; the license is used only when no key is set; with neither,
the free tier runs with nothing configured. For a non-OpenRouter provider (Anthropic,
OpenAI, Google, AWS Bedrock, …) see the
[provider list](https://github.com/CodeBoarding/CodeBoarding-action#more-usage), or re-run
setup from the [CodeBoarding viewer](https://app.codeboarding.org/setup) and pick one.

— opened for you by CodeBoarding